### PR TITLE
[feat] 네비게이션 Context 생성 & 위치 수정, 랭킹보드 스타일링 정리

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,11 +11,14 @@
 
 import React from 'react';
 import { Outlet } from 'react-router-dom';
+import { NavigationProvider } from '../src/context/NavigationContext';
 
 export default function App() {
   return (
     <div>
-      <Outlet />
+      <NavigationProvider>
+        <Outlet />
+      </NavigationProvider>
     </div>
   );
 }

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -1,11 +1,12 @@
-import { React, useState } from 'react';
+import { React, useContext } from 'react';
 import { PiCookingPot, PiCookingPotFill } from 'react-icons/pi';
 import { GoHome, GoHomeFill } from 'react-icons/go';
 import { IoAccessibilityOutline, IoAccessibility } from 'react-icons/io5';
 import { useNavigate } from 'react-router-dom';
+import { NavigationContext } from '../context/NavigationContext';
 
 export default function Navigation() {
-  const [selected, setSelected] = useState('home');
+  const { selected, setSelected } = useContext(NavigationContext);
   const navigate = useNavigate();
 
   return (
@@ -17,7 +18,7 @@ export default function Navigation() {
         style={{ position: 'relative' }}
         onClick={() => {
           setSelected('food');
-          // navigate('/board');
+          navigate('/board');
         }}
         className={`mx-12 text-4xl text-main cursor-pointer ${
           selected === 'food' ? 'selected-icon' : ''

--- a/src/components/Ranking.jsx
+++ b/src/components/Ranking.jsx
@@ -6,9 +6,11 @@ function RankingItem({ rank, thumbnail, name, ingredients, likes }) {
   return (
     <li className="mb-4">
       <div className="drop-shadow-lg">
-        <div className="flex items-center space-x-7">
-          <div className="flex items-center">
-            <span className="font-undong">{rank}</span>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center space-x-7">
+            <div style={{ width: '30px' }}>
+              <span className="font-undong">{rank}</span>
+            </div>
             <img
               src={thumbnail}
               alt="썸네일"
@@ -16,12 +18,16 @@ function RankingItem({ rank, thumbnail, name, ingredients, likes }) {
               height="40px"
               className={rank === 1 ? 'ml-2' : 'ml-1'}
             />
+            <div className="flex flex-col">
+              <span className="font-score font-semibold">{name}</span>
+              <span className="font-score text-sm">
+                {ingredients.join(', ')}
+              </span>
+            </div>
           </div>
-          <div className="flex flex-col">
-            <span className="font-score font-semibold">{name}</span>
-            <span className="font-score text-sm">{ingredients.join(', ')}</span>
+          <div>
+            <span className="font-ansung text-md font-bold">{likes}❤️</span>
           </div>
-          <span className="font-ansung text-md font-bold">{likes}❤️</span>
         </div>
       </div>
     </li>
@@ -44,13 +50,13 @@ export default function Ranking() {
 
   return (
     <div
-      className="hover:cursor-pointer w-full my-4"
+      className="hover:cursor-pointer w-full px-4 my-4"
       onClick={() => {
         navigate('/board');
       }}
     >
       <div className="flex mb-1 justify-between">
-        <span className="font-undong font-bold">Ranking</span>
+        <span className="font-undong font-bold text-2xl">Ranking</span>
         <span className="font-score text-sm">인기많은 레시피를 볼까요?</span>
       </div>
       <ul>

--- a/src/context/NavigationContext.jsx
+++ b/src/context/NavigationContext.jsx
@@ -1,0 +1,13 @@
+import React, { createContext, useState } from 'react';
+
+export const NavigationContext = createContext();
+
+export const NavigationProvider = ({ children }) => {
+  const [selected, setSelected] = useState('');
+
+  return (
+    <NavigationContext.Provider value={{ selected, setSelected }}>
+      {children}
+    </NavigationContext.Provider>
+  );
+};

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -43,7 +43,16 @@ export default function MainPage() {
         {/* // 클릭시 링크 : Link 안에 Ranking을 넣으면 됨 */}
         <Ranking />
       </div>
-      <Navigation />
+      <div
+        style={{
+          position: 'fixed',
+          bottom: '0',
+          width: '100%',
+          maxWidth: '32rem',
+        }}
+      >
+        <Navigation />
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
- 네비게이션바 클릭시 적용되는 아이콘 색상 변경 상태를 url이 변경되고 나서도 해당 selected 상태를 유지한 채로
  적용 되어있게끔 createContext를 사용하여 상태 공유
- 네비게이션바가 페이지의 body 내에서 스크롤이 발생할 만큼 요소가 늘어나도 영향을 받지않고
  sticky하게 현재 화면의 가장 아래에 붙어있도록 수정
- 랭킹보드 안에 px 패딩을 줘서 스타일링 보완